### PR TITLE
Feature(#7): add support to parse basic command format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add support to parse basic command format with arguments (#7) (#8)
+- Add support to parse basic command format with arguments (Issue: [#7](https://github.com/virallalakia/ViralPyCmdParser/issues/7)) (PR: [#8](https://github.com/virallalakia/ViralPyCmdParser/pull/8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
 # Changelog
-All notable changes to this project are documented in this file.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html#semantic-versioning-200).
+
+## [Unreleased]
+### Added
+- Add support to parse basic command format with arguments (#7) (#8)

--- a/src/viralpycmdparser/cmdparser.py
+++ b/src/viralpycmdparser/cmdparser.py
@@ -1,13 +1,16 @@
+import re
+
 from viralpycmdparser.result.cmdparserresult import CmdParserResult
 
 
 class CmdParser:
-    def __init__(self):
-        self.delim = " "
+    def __init__(self, delim=" "):
+        self.delim = delim
 
     def parse(self, cmd_str: str) -> CmdParserResult:
         result = CmdParserResult()
         if cmd_str:
+            cmd_str = re.sub(self.delim + "{2,}", self.delim, cmd_str)
             t = cmd_str.strip(self.delim).split(self.delim)
             result.cmd = t[0]
             if len(t) > 1:

--- a/src/viralpycmdparser/cmdparser.py
+++ b/src/viralpycmdparser/cmdparser.py
@@ -1,2 +1,15 @@
-def hello_world() -> str:
-    return "Hello World"
+from viralpycmdparser.result.cmdparserresult import CmdParserResult
+
+
+class CmdParser:
+    def __init__(self):
+        self.delim = " "
+
+    def parse(self, cmd_str: str) -> CmdParserResult:
+        result = CmdParserResult()
+        if cmd_str:
+            t = cmd_str.strip(self.delim).split(self.delim)
+            result.cmd = t[0]
+            if len(t) > 1:
+                result.args = t[1:]
+        return result

--- a/src/viralpycmdparser/result/cmdparserresult.py
+++ b/src/viralpycmdparser/result/cmdparserresult.py
@@ -1,0 +1,9 @@
+from typing import List
+
+
+class CmdParserResult:
+    def __init__(self, cmd: str = "", args: List[str] = None):
+        self.cmd = cmd
+        if args is None:
+            args = []
+        self.args = args

--- a/tests/test_cmdparser.py
+++ b/tests/test_cmdparser.py
@@ -1,5 +1,20 @@
-from viralpycmdparser import cmdparser
+import pytest
+
+from viralpycmdparser.cmdparser import CmdParser
+from viralpycmdparser.result.cmdparserresult import CmdParserResult
 
 
-def test_hello_world():
-    assert cmdparser.hello_world() == "Hello World"
+@pytest.mark.parametrize(
+    "ip, op",
+    [
+        pytest.param("cmd", CmdParserResult("cmd"), id="Cmd without args"),
+        pytest.param(
+            "cmd arg1", CmdParserResult("cmd", ["arg1"]), id="Cmd with 1 arg"
+        ),
+    ],
+)
+def test_hello_world(ip: str, op: CmdParserResult) -> None:
+    result = CmdParser().parse(ip)
+    assert result.cmd == op.cmd
+    for i in range(len(result.args)):
+        assert result.args[i] == op.args[i]

--- a/tests/test_cmdparser.py
+++ b/tests/test_cmdparser.py
@@ -8,9 +8,7 @@ from viralpycmdparser.result.cmdparserresult import CmdParserResult
     "ip, op",
     [
         pytest.param("cmd", CmdParserResult("cmd"), id="Cmd without args"),
-        pytest.param(
-            "cmd arg1", CmdParserResult("cmd", ["arg1"]), id="Cmd with 1 arg"
-        ),
+        pytest.param("cmd arg1", CmdParserResult("cmd", ["arg1"]), id="Cmd with 1 arg"),
     ],
 )
 def test_hello_world(ip: str, op: CmdParserResult) -> None:

--- a/tests/test_cmdparser.py
+++ b/tests/test_cmdparser.py
@@ -5,14 +5,47 @@ from viralpycmdparser.result.cmdparserresult import CmdParserResult
 
 
 @pytest.mark.parametrize(
-    "ip, op",
+    "delim, ip, op",
     [
-        pytest.param("cmd", CmdParserResult("cmd"), id="Cmd without args"),
-        pytest.param("cmd arg1", CmdParserResult("cmd", ["arg1"]), id="Cmd with 1 arg"),
+        pytest.param(None, "cmd", CmdParserResult("cmd"), id="Cmd without args"),
+        pytest.param(
+            None, "cmd arg1", CmdParserResult("cmd", ["arg1"]), id="Cmd with 1 arg"
+        ),
+        pytest.param(
+            None,
+            "cmd arg1 arg2 arg3",
+            CmdParserResult("cmd", ["arg1", "arg2", "arg3"]),
+            id="Cmd with 3 args",
+        ),
+        pytest.param(
+            None,
+            "  cmd   arg1   arg2    arg3    ",
+            CmdParserResult("cmd", ["arg1", "arg2", "arg3"]),
+            id="Cmd with 3 args and extra spaces",
+        ),
+        pytest.param(
+            ",",
+            "cmd",
+            CmdParserResult("cmd"),
+            id="Cmd without args but with custom delimiter",
+        ),
+        pytest.param(
+            ",",
+            "cmd,arg1",
+            CmdParserResult("cmd", ["arg1"]),
+            id="Cmd with 1 arg and custom delimiter",
+        ),
+        pytest.param(
+            "__",
+            "cmd__arg1 with space__arg2",
+            CmdParserResult("cmd", ["arg1 with space", "arg2"]),
+            id="Cmd with 2 args, with space and custom delimiter",
+        ),
     ],
 )
-def test_hello_world(ip: str, op: CmdParserResult) -> None:
-    result = CmdParser().parse(ip)
+def test_hello_world(delim: str, ip: str, op: CmdParserResult) -> None:
+    cmdparser = CmdParser(delim) if delim else CmdParser()
+    result = cmdparser.parse(ip)
     assert result.cmd == op.cmd
     for i in range(len(result.args)):
         assert result.args[i] == op.args[i]


### PR DESCRIPTION
Resolves issue: #7

### Description
Add support to parse basic command format with args.

### Checklist
- [x] Tests changes
- [x] Docs changes - [Not setup yet]
- [x] Changelog changes in CHANGELOG.md under `[Unreleased]` section

### Changes

#### Added
- Add support to parse basic command format with args
